### PR TITLE
Exclude `update`

### DIFF
--- a/src/cljx/clojurewerkz/balagan/core.cljx
+++ b/src/cljx/clojurewerkz/balagan/core.cljx
@@ -1,4 +1,5 @@
 (ns clojurewerkz.balagan.core
+  (:refer-clojure :exclude [update])
   (:require clojure.walk))
 
 ;;


### PR DESCRIPTION
`update` was added in Clojure 1.7 and causes warnings:

```
WARNING: update already refers to: #'clojure.core/update in namespace: clojurewerkz.balagan.core, being replaced by: #'clojurewerkz.balagan.core/update
```