### PR TITLE
HTTP with TLS for sonatype repositories

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -35,10 +35,10 @@
                            :output-dir "doc/api"}}}
   :aliases  {"all" ["with-profile" "+dev:+master:+1.6"]}
   :prep-tasks [["cljx" "once"] "javac" "compile"]
-  :repositories {"sonatype" {:url "http://oss.sonatype.org/content/repositories/releases"
+  :repositories {"sonatype" {:url "https://oss.sonatype.org/content/repositories/releases"
                              :snapshots false
                              :releases {:checksum :fail :update :always}}
-                 "sonatype-snapshots" {:url "http://oss.sonatype.org/content/repositories/snapshots"
+                 "sonatype-snapshots" {:url "https://oss.sonatype.org/content/repositories/snapshots"
                                        :snapshots true
                                        :releases {:checksum :fail :update :always}}}
   :test-paths ["target/test-classes"]


### PR DESCRIPTION
See https://github.com/technomancy/leiningen/blob/master/doc/FAQ.md for context, and why it should be changed. This leads to issues like:

``` log
Tried to use insecure HTTP repository without TLS: sonatype: http://oss.sonatype.org/content/repositories/releases org/clojure/clojure/maven-metadata.xml
Tried to use insecure HTTP repository without TLS: sonatype-snapshots: http://oss.sonatype.org/content/repositories/snapshots org/clojure/clojure/maven-metadata.xml
```
This PR suggests a fix. While no fix is merged, here is a workaround:
``` clojure
[clojurewerkz/balagan "1.0.5" :exclusions [org.clojure/clojure]]
```